### PR TITLE
Work with any offset / any size of image regardless tile size

### DIFF
--- a/project/scripts/Tiler.gd
+++ b/project/scripts/Tiler.gd
@@ -50,8 +50,10 @@ func tilesetToTile(img) -> void:
 	var height = endOffsetY - offsetY
 
 	# getting the amount of rows and colums
-	var rows = width / tileWidth
-	var cols = height / tileHeight
+	# using int + ceil because image "width" does not have to be divisible by "tileWidth"
+  # Same goes for height. So we get half-filled tiles too
+  var rows = int(ceil(width / tileWidth))
+	var cols = int(ceil(height / tileHeight))
 
 	# getting the total amount of tiles
 	var maxTiles = rows * cols

--- a/project/scripts/main.gd
+++ b/project/scripts/main.gd
@@ -386,17 +386,17 @@ func _on_StartButton_pressed() -> void:
 		
 		
 		# checking if the image is divisible by the tile sizes given
-		if width % tileWidth != 0 || height % tileHeight != 0:
-			print(width , " : " , tileWidth, " | ", height, " : ", tileHeight)
-			$InfoText.visible = true
+		# if width % tileWidth != 0 || height % tileHeight != 0:
+			# print(width , " : " , tileWidth, " | ", height, " : ", tileHeight)
+			# $InfoText.visible = true
 		
-			var tween = Tween.new()
-			add_child(tween)
-			tween.interpolate_property($InfoText, "modulate:a", modulate.a, 0.0, 1.0, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
-			tween.playback_speed = 0.5
-			tween.start()
+			# var tween = Tween.new()
+			# add_child(tween)
+			# tween.interpolate_property($InfoText, "modulate:a", modulate.a, 0.0, 1.0, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+			# tween.playback_speed = 0.5
+			# tween.start()
 			
-			return
+			# return
 		
 		# setting running to true to stop new processes from happening
 		running = true


### PR DESCRIPTION
Because sometimes we may need to cut makeshift / temporary / bad images, that are not exact tilemaps, and then the dimensions can not be exact. For dimensions to be exact one would have to pre-edit the image in an image editor.... But since tiling it gives one the opportunity to have the useless tiles trimmed off, this seems an unnecessary step. So, trim it anyway! Regardless if dimensions are divisible.